### PR TITLE
build fix for ubuntu 20.04

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,6 @@
 #include <stdint.h>
 #include <errno.h>
 #include <time.h>
-//#include <stropts.h>
 #include <sys/ioctl.h>
 #include <linux/fs.h>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,8 @@
 #include <stdint.h>
 #include <errno.h>
 #include <time.h>
-#include <stropts.h>
+//#include <stropts.h>
+#include <sys/ioctl.h>
 #include <linux/fs.h>
 
 #include "error.hpp"


### PR DESCRIPTION
stropts.h seems not supported on Ubuntu/Linux, something with streams. Replacing with #include <sys/ioctl.h> worked for me.

Source: https://forums.fedoraforum.org/showthread.php?194667-error-stropts-h-No-such-file-or-directory